### PR TITLE
Specify that this package only runs on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.1",
   "description": "A screengrabbing library which uses the Windows Desktop Duplication API",
   "main": "index.js",
+  "os": [
+    "win32"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "install": "node-gyp rebuild"


### PR DESCRIPTION
This way, when running on other operating systems, when trying to install this lib, user will be informed it's not compatible with the current OS:

```
npm ERR! code EBADPLATFORM
Unsupported platform for windows-desktop-duplication@1.0.1: wanted {"os":"win32","arch":"any"} (current: {"os":"darwin","arch":"x64"})
Valid OS:    win32
Valid Arch:  any
Actual OS:   darwin
Actual Arch: x64
```

And for people who want it as dependency in a cross-platform package, they can add it as an optional dependency, so it will be installed only under supported operating systems:

```
"optionalDependencies": {
    "windows-desktop-duplication": "^1.0.1"
},
```

In this case, it will be installed as usual under Windows.
While under MacOS it will display:

```
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: windows-desktop-duplication@1.0.1 (node_modules/windows-desktop-duplication): Unsupported platform for windows-desktop-duplication@1.0.1: wanted {"os":"win32","arch":"any"} (current: {"os":"darwin","arch":"x64"})
```

A good example of usage of "os" and "optionalDependencies" package.json properties can be seen on FSEvents package (which is MacOS specific): https://github.com/fsevents/fsevents/blob/master/package.json, and Chokidar (which is cross-platform and has FSEvents as optional dependency): https://github.com/paulmillr/chokidar/blob/master/package.json